### PR TITLE
lab 03-03 03-bonus security auditors roles files

### DIFF
--- a/supplemental/03-03/lonervamp-securityauditors-stackset.yml
+++ b/supplemental/03-03/lonervamp-securityauditors-stackset.yml
@@ -1,0 +1,28 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Creates a Security Auditor Role in linked accounts to allow security auditors in the org root account to assume a SecurityAuditRole in linked accounts to do audit things. Like run cloudmapper.
+Parameters:
+
+  OrganizationAccountId:
+    Description: The account ID of the parent org root account.
+    MinLength: '12'
+    AllowedPattern: '[0-9]+'
+    MaxLength: '12'
+    Type: String
+    Default: '258748242541'
+
+Resources: 
+  SecurityAuditorsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: SecurityAuditorsRole
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/SecurityAudit"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            AWS: !Sub 
+              - 'arn:aws:iam::${ORGANID}:root'
+              - { ORGANID: !Ref OrganizationAccountId }
+          Action: "sts:AssumeRole"

--- a/supplemental/03-03/lonervamp-securityauditors.yml
+++ b/supplemental/03-03/lonervamp-securityauditors.yml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Creates a group, role, and policy to allow securityauditors SecurityAudit permissions to the account.
+Resources: 
+  SecurityAuditorsRoleAccess:
+    Type: AWS::IAM::Group
+    Properties:
+      GroupName: SecurityAuditorsTeamDeimos
+  SecurityAuditorsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: SecurityAuditorsRole
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/SecurityAudit"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal: { "AWS": !Sub "arn:aws:iam::${AWS::AccountId}:root" }
+          Action: "sts:AssumeRole"
+          Condition:
+            Bool: 
+              aws:MultiFactorAuthPresent: "true"
+  AssumeSecurityAuditorsRole:
+    Type: AWS::IAM::Policy
+    Properties:
+      Groups:
+        - !Ref SecurityAuditorsRoleAccess
+      PolicyName: SecurityAuditorsRoleAccess
+      PolicyDocument:
+        Id: AllowAssumption
+        Version: 2012-10-17
+        Statement:
+        -
+          Sid: AssumeSecurityAuditorsRole
+          Effect: Allow
+          Action: "sts:AssumeRole"
+          Resource: arn:aws:iam::*:role/SecurityAuditorsRole


### PR DESCRIPTION
Uploading lab 03-03 03-bonus lab to create a security auditors role using CF templates. These are the first templates I've made beyond just replacing variables, and they seem to work for me in my root, production, and security-tools accounts.